### PR TITLE
ci: remove Node 18 and add Node 24 to test and benchmark matrices

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Node 18 is now EOL, so removing it from CI workflows. Adding Node 24 to ensure compatibility with the latest version.
